### PR TITLE
CI: use java 11

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,16 +27,16 @@ jobs:
           dependencies-cache-enabled: true
           configuration-cache-enabled: true
   linux:
-    name: Linux (Java 9)
+    name: Linux (Java 11)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
-      - name: Set up JDK 9
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 9
+          java-version: 11
       - name: Build & Test
         uses: eskatos/gradle-command-action@v1
         with:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -19,10 +19,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 10
-      - name: Set up JDK 9
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 9
+          java-version: 11
       - name: Publish
         env:
           PROPS_RELEASE: "-Prc=1 -Pgh -Prelease=false -PskipJavadoc -PskipAutostyle"


### PR DESCRIPTION
Java 9 doesn’t work with the release flag in gradle.